### PR TITLE
Improved add command perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add and Run commands
+- Add, Remove and Run commands
 - Include and Dev options
 - Package functions to get/filter packages and parse name/version strings
 - Mono repo function to load mono repo config from directory in a mono repo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enzsft/mono",
-  "version": "1.0.0-alpha.22",
+  "version": "1.0.0-alpha.25",
   "description": "Manage JavaScript mono repos with ease. 😲",
   "keywords": [
     "mono",

--- a/src/__tests__/packages.test.ts
+++ b/src/__tests__/packages.test.ts
@@ -2,47 +2,54 @@ import { tmpdir } from "os";
 import { resolve } from "path";
 import { createMonoRepo, deleteMonoRepo } from "../mono-repo";
 import {
-  extractPackageName,
-  extractPackageVersion,
   filterPackages,
+  getPackageName,
   getPackages,
+  getPackageVersion,
 } from "../packages";
 
-describe("getPackages", () => {
-  const monoRepoDir = resolve(process.cwd(), "__mono_repo_fixture__packages__");
-  const monoRepo = {
-    __dir: "",
+const monoRepoDir = resolve(process.cwd(), "__mono_repo_fixture__packages__");
+const monoRepo = {
+  __dir: "",
+  license: "MIT",
+  name: "packages",
+  private: true,
+  version: "1.0.0",
+  workspaces: ["packages/*"],
+};
+const packages = [
+  {
+    __dir: resolve(monoRepoDir, "packages/a"),
     license: "MIT",
-    name: "packages",
-    private: true,
+    name: "@packages/a",
+    scripts: { test: "touch test.txt" },
     version: "1.0.0",
-    workspaces: ["packages/*"],
-  };
-  const packages = [
-    {
-      __dir: resolve(monoRepoDir, "packages/one"),
-      license: "MIT",
-      name: "@packages/one",
-      scripts: { test: "touch test.txt" },
-      version: "1.0.0",
-    },
-    {
-      __dir: resolve(monoRepoDir, "packages/two"),
-      license: "MIT",
-      name: "@packages/two",
-      scripts: { test: "touch test.txt" },
-      version: "1.0.0",
-    },
-  ];
+  },
+  {
+    __dir: resolve(monoRepoDir, "packages/b"),
+    license: "MIT",
+    name: "@packages/b",
+    scripts: { test: "touch test.txt" },
+    version: "1.0.0",
+  },
+  {
+    __dir: resolve(monoRepoDir, "packages/c"),
+    license: "MIT",
+    name: "@packages/c",
+    scripts: { test: "touch test.txt" },
+    version: "1.0.0",
+  },
+];
 
-  beforeEach(async () => {
-    await createMonoRepo(monoRepoDir, monoRepo, packages);
-  });
+beforeEach(async () => {
+  await createMonoRepo(monoRepoDir, monoRepo, packages);
+});
 
-  afterEach(async () => {
-    await deleteMonoRepo(monoRepoDir);
-  });
+afterEach(async () => {
+  await deleteMonoRepo(monoRepoDir);
+});
 
+describe("getPackages", () => {
   it("should get all packages in the mono repo", async () => {
     const foundPackages = await getPackages(monoRepoDir);
 
@@ -51,9 +58,7 @@ describe("getPackages", () => {
 
   it("should traverse file tree up until it finds a mono repo package.json", async () => {
     // Start search inside a package in a mono repo
-    const foundPackages = await getPackages(
-      resolve(monoRepoDir, "packages/one"),
-    );
+    const foundPackages = await getPackages(resolve(monoRepoDir, "packages/a"));
 
     // Should have walked the file tree up until it found the
     // mono repo config with the workspace globs
@@ -68,71 +73,83 @@ describe("getPackages", () => {
 });
 
 describe("filterPackages", () => {
-  const packages = [
-    {
-      __dir: "packages/one",
-      license: "MIT",
-      name: "one",
-      scripts: { test: "touch test.txt" },
-      version: "1.0.0",
-    },
-    {
-      __dir: "packages/two",
-      license: "MIT",
-      name: "two",
-      scripts: { test: "touch test.txt" },
-      version: "1.0.0",
-    },
-    {
-      __dir: "packages/three",
-      license: "MIT",
-      name: "three",
-      scripts: { test: "touch test.txt" },
-      version: "1.0.0",
-    },
-  ];
-
   it("should return all matching packages", () => {
-    const [one, two, three] = packages;
+    const [a, b, c] = packages;
 
     // Name only
-    expect(filterPackages(packages, "one")).toEqual([one]);
-    expect(filterPackages(packages, "one,two")).toEqual([one, two]);
-    expect(filterPackages(packages, "two,three")).toEqual([two, three]);
+    expect(filterPackages(packages, "@packages/a")).toEqual([a]);
+    expect(filterPackages(packages, "@packages/a,@packages/c")).toEqual([a, c]);
+    expect(filterPackages(packages, "@packages/b,@packages/c")).toEqual([b, c]);
 
     // Wildcard only
-    expect(filterPackages(packages, "*")).toEqual([one, two, three]);
-    expect(filterPackages(packages, "t*")).toEqual([two, three]);
+    expect(filterPackages(packages, "*")).toEqual([a, b, c]);
+    expect(filterPackages(packages, "@packages/*")).toEqual([a, b, c]);
 
     // Ensure not all strings are wildcarded
-    expect(filterPackages(packages, "o")).toEqual([]);
+    expect(filterPackages(packages, "@packages")).toEqual([]);
 
     // Name/wildcard mix
-    expect(filterPackages(packages, "one,t*")).toEqual([one, two, three]);
+    expect(filterPackages(packages, "@packages/a,@packages*")).toEqual([
+      a,
+      b,
+      c,
+    ]);
   });
 });
 
-describe("extractPackageName", () => {
+describe("getPackageName", () => {
   it("should extract the package name", () => {
-    expect(extractPackageName("test")).toBe("test");
-    expect(extractPackageName("test@1")).toBe("test");
-    expect(extractPackageName("test@1.0")).toBe("test");
-    expect(extractPackageName("test@^1.0.0")).toBe("test");
-    expect(extractPackageName("@test/one")).toBe("@test/one");
-    expect(extractPackageName("@test/one@1.0.0")).toBe("@test/one");
+    expect(getPackageName("test")).toBe("test");
+    expect(getPackageName("test@1")).toBe("test");
+    expect(getPackageName("test@1.0")).toBe("test");
+    expect(getPackageName("test@^1.0.0")).toBe("test");
+    expect(getPackageName("@test/one")).toBe("@test/one");
+    expect(getPackageName("@test/one@1.0.0")).toBe("@test/one");
   });
 });
 
-describe("extractPackageVersion", () => {
-  it("should extract the package version", () => {
-    expect(extractPackageVersion("test@1")).toBe("1");
-    expect(extractPackageVersion("test@1.0.0")).toBe("1.0.0");
-    expect(extractPackageVersion("test@^1.0.0")).toBe("^1.0.0");
-    expect(extractPackageVersion("@test/one@1.0.0")).toBe("1.0.0");
+describe("getPackageVersion", () => {
+  it("should extract the package version", async () => {
+    expect(await getPackageVersion("test@1", packages)).toEqual({
+      modifier: "",
+      version: "1",
+    });
+    expect(await getPackageVersion("test@1.0.0", packages)).toEqual({
+      modifier: "",
+      version: "1.0.0",
+    });
+    expect(await getPackageVersion("test@^1.0.0", packages)).toEqual({
+      modifier: "^",
+      version: "1.0.0",
+    });
+    expect(await getPackageVersion("@test/one@1.0.0", packages)).toEqual({
+      modifier: "",
+      version: "1.0.0",
+    });
   });
 
-  it("should return null if no version is present", () => {
-    expect(extractPackageVersion("test")).toBeNull();
-    expect(extractPackageVersion("@test/one")).toBeNull();
+  it("should return the latest from NPM if no version is present", async () => {
+    expect(await getPackageVersion("@enzsft/npm-fixture", packages)).toEqual({
+      modifier: "^",
+      version: "1.0.1",
+    });
+  });
+
+  it("should return the version of the package in the mono repo if no version is present", async () => {
+    expect(await getPackageVersion("@packages/a", packages)).toEqual({
+      modifier: "^",
+      version: "1.0.0",
+    });
+  });
+
+  it("should throw if the package does not exist", async () => {
+    expect.assertions(1);
+    try {
+      await getPackageVersion("this-will-never-exist-surely", packages);
+    } catch (error) {
+      expect(error).toEqual(
+        new Error("NPM package 'this-will-never-exist-surely' does not exist"),
+      );
+    }
   });
 });

--- a/src/commands/__tests__/add.test.ts
+++ b/src/commands/__tests__/add.test.ts
@@ -364,11 +364,28 @@ describe("add", () => {
     expect(checkNodeModuleExists("@add/b-package-other")).toBe(true);
   });
 
-  it("should reject with eit code if Yarn install fails", async () => {
+  it("should reject with exit code if the package does not exist", async () => {
     try {
       expect.assertions(1);
       await cli.start(
         buildArgv("add hope-this-package-never-exists -i @add/a-package"),
+      );
+    } catch (error) {
+      expect(error).toEqual(
+        new Error(
+          "NPM package 'hope-this-package-never-exists' does not exist",
+        ),
+      );
+    }
+  });
+
+  it("should reject with exit code if Yarn install fails", async () => {
+    try {
+      expect.assertions(1);
+      await cli.start(
+        buildArgv(
+          "add hope-this-package-never-exists@bad-version -i @add/a-package",
+        ),
       );
     } catch (error) {
       expect(typeof error.code).toBe("number");

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -2,6 +2,7 @@ import { ICommand } from "@enzsft/cli";
 import chalk from "chalk";
 import { exec } from "child_process";
 import { readJson, writeJson } from "fs-extra";
+import { EOL } from "os";
 import { resolve } from "path";
 import { createConsoleLogger } from "../logger";
 import { includeOption } from "../options/include";
@@ -35,11 +36,9 @@ export const createRemoveCommand = (
 
     // Log out all the packages to be removed and from what packages
     logger.log(
-      `Removing ${chalk.greenBright(
-        removePackageNames.join(", "),
-      )} in the following packages:[${targetPackages
-        .map(p => chalk.blueBright(p.name))
-        .join(`, `)}]`,
+      `Removing from the following packages:${EOL}${chalk.blueBright(
+        targetPackages.map(p => p.name).join(EOL),
+      )}`,
     );
 
     // Remove the dependency from all target package.json files if they exist

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,6 +1,7 @@
 import { ICommand } from "@enzsft/cli";
 import chalk from "chalk";
 import { exec } from "child_process";
+import { EOL } from "os";
 import { applyRandomColor } from "../colors";
 import { createConsoleLogger } from "../logger";
 import { includeOption } from "../options/include";
@@ -43,9 +44,9 @@ export const createRunCommand = (
       logger.log(
         `Running script ${chalk.greenBright(
           script,
-        )} in the following packages: [${targetPackages
-          .map(p => chalk.blueBright(p.name))
-          .join(`,  `)}]`,
+        )} in the following packages:${EOL}${chalk.blueBright(
+          targetPackages.map(p => p.name).join(EOL),
+        )}]`,
       );
       // Build executor functions
       const executors = targetPackages

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,20 @@ export interface IPackage {
 }
 
 /**
+ * NPM package version spec
+ */
+export interface IVersionSpec {
+  /**
+   * Version such as 1.0.0
+   */
+  version: string;
+  /**
+   * Version modifier such as ^
+   */
+  modifier: string;
+}
+
+/**
  * Run command options
  */
 export interface IRunCommandOptions {


### PR DESCRIPTION
Now installing all packages the same way. Writing all dependencies local and NPM into package.jsons and running yarn once to install them all. NPM versions are obtains via CLI using exec. This *greatly* speeds up adding dependencies across lots of packages

Closes issue #3 

